### PR TITLE
Attach  HttpRequestMessage to HttpResponse

### DIFF
--- a/Scotch.Tests/AlbumService.cs
+++ b/Scotch.Tests/AlbumService.cs
@@ -47,5 +47,13 @@ namespace Scotch.Tests
 
             return album;
         }
+
+        public async Task<string> GetOriginalRequestUrl(int id)
+        {
+            var url = $"http://jsonplaceholder.typicode.com/albums/{id}";
+            var response = await _httpClient.GetAsync(url);
+
+            return response.RequestMessage.RequestUri.ToString();
+        }
     }
 }

--- a/Scotch.Tests/ReplayingTests.cs
+++ b/Scotch.Tests/ReplayingTests.cs
@@ -37,5 +37,15 @@ namespace Scotch.Tests
             response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
 
         }
+
+        [Fact]
+        public async Task ReplayedResponseHasAttachedRequest()
+        {
+            var httpClient = HttpClients.NewHttpClient(_testCassettePath, ScotchMode.Replaying);
+            var albumService = new AlbumService(httpClient);
+            var originalUrl = await albumService.GetOriginalRequestUrl(2);
+
+            originalUrl.ShouldBe("http://jsonplaceholder.typicode.com/albums/2");
+        }
     }
 }

--- a/Scotch/HttpInteraction.fs
+++ b/Scotch/HttpInteraction.fs
@@ -13,7 +13,17 @@ type Request =
       URI : string
       RequestHeaders : HeaderDictionary
       ContentHeaders : HeaderDictionary
-      Body : string }
+      Body : string } with
+    member this.ToHttpRequestMessage () =
+        let result = new HttpRequestMessage()
+        result.Method <- new HttpMethod(this.Method)
+        result.RequestUri <- new System.Uri(this.URI)
+        for h in this.RequestHeaders do result.Headers.TryAddWithoutValidation(h.Key, h.Value.ToString()) |> ignore
+        let content = new ByteArrayContent(Encoding.UTF8.GetBytes(this.Body))
+        for h in this.ContentHeaders do content.Headers.TryAddWithoutValidation(h.Key, h.Value.ToString()) |> ignore
+        result.Content <- content
+        result
+
 
 type Status =
     { Code : HttpStatusCode

--- a/Scotch/ReplayingHandler.fs
+++ b/Scotch/ReplayingHandler.fs
@@ -19,6 +19,7 @@ type ReplayingHandler(innerHandler:HttpMessageHandler, cassettePath:string) =
             let matchedInteraction = Seq.find (fun i -> requestsMatch receivedRequest i.Request) interactions
             let matchedResponse = matchedInteraction.Response
             let responseMessage = matchedResponse.ToHttpResponseMessage()
+            responseMessage.RequestMessage <- matchedInteraction.Request.ToHttpRequestMessage()
             return responseMessage
         }
 


### PR DESCRIPTION
When you make a request using .NET's `HttpClient` - the `HttpResponseMessage` normally has the originating `HttpRequestMessage` attached to it on the `RequestMessage` property.  This is useful for constructing absolute URIs from relative URLs found in the response message such as Form `action` attributes and relative 301/302 redirects.

To that end, Scotch should attach a reproduction of the original `HttpRequestMessage` to it's deserialized `HttpResponseMessage`.